### PR TITLE
fix bug if parameters are none

### DIFF
--- a/apiaudio/helper_classes.py
+++ b/apiaudio/helper_classes.py
@@ -19,7 +19,7 @@ class CreatableResource(APIRequest):
 class RetrievableResource(APIRequest):
     @classmethod
     def retrieve(cls, scriptId, section=None, parameters=None, public=None, vast=None):
-        params = parameters.copy() or {}
+        params = parameters.copy() if parameters else {}
         params.update({"scriptId": scriptId})
 
         if section:


### PR DESCRIPTION
when no param is sent, it was failing: `AttributeError: 'NoneType' object has no attribute 'copy'`