### PR TITLE
check for multiple placeholders in api_key

### DIFF
--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -11,6 +11,9 @@ class APIRequest:
         PLACEHOLDERS = ["your-key", "APIKEY", "API_KEY"]
         if api_key == None or api_key in PLACEHOLDERS:
             api_key = os.environ.get("apiaudio_key", None)
+        # backwards compatibility with aflr env variables
+        if api_key == None:
+                api_key = os.environ.get("aflr_key", None)
         if not isinstance(api_key, str):
             raise TypeError("api_key must be of type string.")
 

--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -8,7 +8,8 @@ from requests.exceptions import HTTPError
 
 class APIRequest:
     def _api_key_checker(api_key=None):
-        if api_key == None or api_key == "your-key":
+        PLACEHOLDERS = ["your-key", "APIKEY", "API_KEY"]
+        if api_key == None or api_key in PLACEHOLDERS:
             api_key = os.environ.get("apiaudio_key", None)
         if not isinstance(api_key, str):
             raise TypeError("api_key must be of type string.")

--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -10,10 +10,8 @@ class APIRequest:
     def _api_key_checker(api_key=None):
         PLACEHOLDERS = ["your-key", "APIKEY", "API_KEY"]
         if api_key == None or api_key in PLACEHOLDERS:
-            api_key = os.environ.get("apiaudio_key", None)
-        # backwards compatibility with aflr env variables
-        if api_key == None:
-                api_key = os.environ.get("aflr_key", None)
+            # aflr_key is for backward compatibility with the old name of env vars.
+            api_key = os.environ.get("apiaudio_key", os.environ.get("aflr_key", None))
         if not isinstance(api_key, str):
             raise TypeError("api_key must be of type string.")
 


### PR DESCRIPTION
Hey there, I need a quick review. Added a few more placeholders for api_key.
what does this mean? and why its useful?
Before this, If someone copied a recipe and used the environment variable to setup the key (recommended method), the recipe code would fail, because api_key in the code takes precedence over env variable.

Luckily, we have a “placeholder detector” so if the placeholder is found, such as:
```
apiaudio.api_key = "your-key"
apiaudio.api_key = "APIKEY"
apiaudio.api_key = "API_KEY"
```
Then it will automatically search for the environment variable `apiaudio_key` as we detect this is a placeholder.
This is useful to not bother users innecessarily.
This is useful to automate recipe code testing in our libraries (we can now setup a env variable and run all the code without having to modify any line of code).

In fact, I did this because of the latter, but we have an extra checker for the recipes users as well.

----
Second change - Backwards compatibility for `aflr_key`, the api_key environment variable used before `apiaudio_key`