### PR TITLE
Adding in sdk version to api calls

### DIFF
--- a/apiaudio/__init__.py
+++ b/apiaudio/__init__.py
@@ -3,6 +3,7 @@
 
 # Configuration variables
 
+sdk_version = "0.12.3"
 api_key = None
 client_id = None
 api_base = "https://v1.api.audio"

--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -4,6 +4,7 @@ import shutil
 import os
 import requests
 from requests.exceptions import HTTPError
+from . import sdk_version
 
 
 class APIRequest:
@@ -30,7 +31,7 @@ class APIRequest:
     @classmethod
     def _build_header(cls):
         cls._api_key_checker(apiaudio.api_key)
-        return {"x-api-key": apiaudio.api_key}
+        return {"x-api-key": apiaudio.api_key, "x-sdk-version": sdk_version}
 
     @classmethod
     def _post_request(cls, json, url=None):
@@ -57,7 +58,7 @@ class APIRequest:
         cls._expanded_raise_for_status(r)
 
         return r.content
-    
+
     @classmethod
     def _delete_request(cls, url=None, path_param=None, request_params=None):
         url = url or f"{apiaudio.api_base}{cls.resource_path}"
@@ -73,7 +74,6 @@ class APIRequest:
 
         return r.json()
 
-
     @classmethod
     def _put_request(cls, data, url=None, headers=None):
         url = url or f"{apiaudio.api_base}{cls.resource_path}"
@@ -81,11 +81,11 @@ class APIRequest:
         r = requests.put(url=url, headers=headers, data=data)
 
         cls._expanded_raise_for_status(r)
-        
+
         if r.status_code != 200:
             raise ValueError("Error performing the PUT request")
 
-        # since aws s3 does not return a body on PUT requests, 
+        # since aws s3 does not return a body on PUT requests,
         # r.json() does not work here
         return r
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,29 @@
-import setuptools
+import os
+import re
+from setuptools import setup, find_packages
+
+ROOT = os.path.dirname(__file__)
+VERSION_RE = re.compile(r"""sdk_version = ['"]([0-9.]+)['"]""")
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+
+def get_version():
+    init = open(os.path.join(ROOT, "apiaudio", "__init__.py")).read()
+    return VERSION_RE.search(init).group(1)
+
+
+setup(
     name="apiaudio",
-    version="0.12.2",
+    version=get_version(),
     author="salih",
     author_email="salih@aflorithmic.ai",
     description="Python SDK for api.audio API",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/aflorithmic/aflr_python",
-    packages=setuptools.find_packages(),
+    url="https://github.com/aflorithmic/apiaudio-python",
+    packages=find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
https://app.serverless.com/aflorithmic/apps/ms-birdcache/ms-birdcache/staging/eu-west-1/explorer/5383485c-918b-4110-b268-3549b4f79b28?mode=invocations&timestamp=2022-01-11T17%3A51%3A09.534204Z

x-sdk-version is added to headers. i can also write a get_sdk_version() decorator if you want @Sjhunt93 @martinezpl 