### PR TITLE
Adding processing loop in Speech and Mastering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The SDK has been renamed. `aflr` v0.8.1 is still up in pip (pypi), but will not 
   - [Birdcache](#birdcache)
   - [Lexi](#lexi)
   - [Connector](#connector)
+  - [Logging](#logging)
 - [Authors](#authors)
 - [License](#license)
 
@@ -750,7 +751,18 @@ Available methods:
     status = apiaudio.Connector.connection(
       connection_id="af2fe14a-aa6b-4a97-b430-a072c38b11ff"
     )
-    
+
+### Logging <a name = "logging"></a>
+
+By default, warnings issued by API are logged in the console output. Additionally, some behaviors are logged on informational level (e.g. "In progress..." indicators during longer processing times). 
+The level of logging can be controlled choosing from the standard levels in Python's `logging` library.
+
+  - Decreasing logging level for more detailed logs:
+    ```python
+    apiaudio.set_logger_level("INFO")
+    # apiaudio.set_logger_level("CRITICAL") - set the highest level to disable logs
+    ```
+
 # Maintainers <a name = "maintainers"> </a>
 
 - https://github.com/zeritte

--- a/README.md
+++ b/README.md
@@ -461,7 +461,7 @@ Mastering methods are:
     - `vast` (boolean) - Boolean flag that allows to create a VAST file of your mastered file. The `vast` flag only works if `public` is `True`. Default value is `False`.
     - `endFormat` (list) - List of audio formats to be produced. Valid formats are: `["wav", "mp3" (default), "flac", "ogg", "mp3_very_low", "mp3_low", "mp3_medium", "mp3_high", "mp3_very_high"]`
     - `forceLength` (int) - force the audio length of the mastered track (in seconds).
-    - `audience` (list) - List of dicts containing the personalisation parameters. This parameter depends on the number of parameters you used in your [script](#script) resource. In the script documentation example above, we used 2 parameters: `username` and `location`, and in the following example below we want to produce the script for username `salih` with location `Barcelona`. If audience is not provided, the fallback track will be created.
+    - `audience` (dict) - Dictionary containing the personalisation parameters. This parameter depends on the number of parameters you used in your [script](#script) resource. In the script documentation example above, we used 2 parameters: `username` and `location`, and in the following example below we want to produce the script for username `salih` with location `Barcelona`. If audience is not provided, the fallback track will be created.
     - `mediaFiles` (list) - List of dicts containing the media files. This parameter depends on the media file tags used in the [script](#script) resource and the media files you have in your account. For example, if the script contains `<<media::myrecording>>` plus `<<media::mysong>>`, and you want to attach myrecording to mediaId = "12345", and mysong to mediaId = "67890" then `mediaFiles = [{"myrecording":"12345", "mysong":"67890"}]`.
     - `mediaVolumeTrim` (float) - Floating point varible that allows you to trim the volume of uploaded media files (in dB). This attribute has a valid range of -12 to 12 dB and applies to all media files included in a single mastering call. Clipping protection is not provided so only make incremental adjustments.
     - `connectors` (list) - List of dicts specifying configuration for particular 3rd party connection. For guidelines in context of supported 3rd party application, see [connectors documentation](https://docs.api.audio/docs/what-are-connectors).
@@ -471,7 +471,7 @@ Mastering methods are:
     response = apiaudio.Mastering.create(
         scriptId="id-1234",
         soundTemplate="parisianmorning",
-        audience=[{"username":"salih", "location":"barcelona"}]
+        audience={"username":"salih", "location":"barcelona"}
     )
     ```
 

--- a/apiaudio/__init__.py
+++ b/apiaudio/__init__.py
@@ -3,13 +3,12 @@
 
 # Configuration variables
 
-sdk_version = "0.14.0"
+sdk_version = "0.14.1"
 
 api_key = None
 client_id = None
 api_base = "https://v1.api.audio"
 upload_api_base = "https://file.api.audio"  # not implemented yet.
-log_warnings = True
 
 # future
 api_version = None
@@ -28,3 +27,10 @@ from apiaudio.logging import SDKLogger
 
 _logger = SDKLogger()
 _version_warning_issued = False
+
+def set_logger_level(level):
+    available_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    level = level.upper()
+    assert level in available_levels, f"Available logging levels: {available_levels}"
+    
+    _logger = SDKLogger(level=level)

--- a/apiaudio/api_resources/mastering.py
+++ b/apiaudio/api_resources/mastering.py
@@ -8,3 +8,4 @@ from apiaudio.helper_classes import (
 class Mastering(CreatableResource, RetrievableResource, DownloadableResource):
     OBJECT_NAME = "mastering"
     resource_path = "/mastering"
+    loop_status_code = 202

--- a/apiaudio/api_resources/speech.py
+++ b/apiaudio/api_resources/speech.py
@@ -8,3 +8,4 @@ from apiaudio.helper_classes import (
 class Speech(CreatableResource, RetrievableResource, DownloadableResource):
     OBJECT_NAME = "speech"
     resource_path = "/speech"
+    loop_status_code = 202

--- a/apiaudio/logging.py
+++ b/apiaudio/logging.py
@@ -29,7 +29,7 @@ class CustomFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def SDKLogger(level=logging.WARNING):
+def SDKLogger(level="WARNING"):
     """
     Add a stream handler for the given name and level to the logging module.
     By default, this logs all apiaudio messages to ``stdout``.
@@ -42,7 +42,7 @@ def SDKLogger(level=logging.WARNING):
     :param level: Logging level, e.g. ``logging.INFO``
     """
     logger = logging.getLogger("apiaudio")
-    logger.setLevel(level)
+    logger.setLevel(getattr(logging, level))
 
     # create console handler with a higher log level
     handler = logging.StreamHandler()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,9 +2,19 @@ import apiaudio
 import pprint
 import pytest
 import os 
+import logging
 
 apiaudio.api_key = os.environ["AFLR_API_KEY"]
 #apiaudio.api_base="https://staging-v1.api.audio"
+
+def test_level_setting():
+    assert apiaudio._logger.level is logging.WARNING
+    apiaudio.set_logger_level("DEBUG")
+    assert apiaudio._logger.level is logging.DEBUG
+
+def test_processing_loop():
+    speech = apiaudio.Speech.create(scriptId="longProcessing", voice="Dieter")
+    assert len(speech) == 3  # number of sections in the script
 
 def test_list_parameters():
     assert len(apiaudio.Voice.list_parameters()) > 0 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,18 +3,15 @@ import pprint
 import pytest
 import os 
 import logging
+from time import time
 
 apiaudio.api_key = os.environ["AFLR_API_KEY"]
-#apiaudio.api_base="https://staging-v1.api.audio"
+apiaudio.api_base="https://staging-v1.api.audio"
 
 def test_level_setting():
     assert apiaudio._logger.level is logging.WARNING
     apiaudio.set_logger_level("DEBUG")
     assert apiaudio._logger.level is logging.DEBUG
-
-def test_processing_loop():
-    speech = apiaudio.Speech.create(scriptId="longProcessing", voice="Dieter")
-    assert len(speech) == 3  # number of sections in the script
 
 def test_list_parameters():
     assert len(apiaudio.Voice.list_parameters()) > 0 
@@ -63,3 +60,18 @@ def test_script_versions():
         key = str(ver) + "|default"
         assert key in speech.keys()
         assert speech[key]["status_code"] == "201"
+
+def test_processing_loop_speech():
+    t0 = time()
+    speech = apiaudio.Speech.create(scriptId="longProcessing", voice="Dieter")
+    assert len(speech) == 3  # number of sections in the script
+    assert time() - t0 > 30
+
+def test_processing_loop_mastering():
+    t0 = time()
+    apiaudio.Script.create(scriptId="test_sdk", scriptText="<<sectionName::question>> Hey! Do you know we support multiple voices from different providers in the same script? I am a polly voice from Amazon. <<sectionName::answer>> I am Azure voice from Microsoft. I think Azure voices sound awesome.")
+    apiaudio.Speech.create(scriptId="test_sdk", voice="brandon")
+    mastering = apiaudio.Mastering.create(scriptId="test_sdk", forceLength=700)
+    print(mastering)
+    assert "url" in mastering
+    assert time() - t0 > 30


### PR DESCRIPTION
Implementing a `loop_status_code` attribute that triggers loops by repeating the requests. 

The attribute is specified in the definition of API resource. 

Speech.create, retrieve and download now do not return nor timeout when processing takes long (unless using sync=False flag). The methods keep running until a success/error code is returned.

Also some logging updates.