### PR TITLE
CircleCI config: publish new version in pip, update latest version parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,7 @@ jobs:
     parameters:
       repo_path:
         type: string
-        default: aflorithmic/aflr_python_client
-      default_branch:
-        type: string
-        default: main
+        default: aflorithmic/apiaudio-python
       semgrep_deployment_id:
         type: integer
         default: 283
@@ -26,6 +23,8 @@ jobs:
             python -m semgrep_agent \
               --publish-deployment << parameters.semgrep_deployment_id >> \
               --publish-token $SEMGREP_APP_TOKEN
+
+
 
 workflows:
   semgrep-scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,16 @@
 version: 2.1
 
+config_blocks:
+  only_tags: &only_tags
+    filters:
+      branches:
+        ignore: /.*/
+      tags:
+        only: /^v[0-9]+(\.[0-9]+)*$/
+
+orbs:
+  aws-cli: circleci/aws-cli@3.1
+
 jobs:
   semgrep-scan:
     parameters:
@@ -24,10 +35,48 @@ jobs:
               --publish-deployment << parameters.semgrep_deployment_id >> \
               --publish-token $SEMGREP_APP_TOKEN
 
+  pip-publish:
+    docker:
+      - image: cimg/python:3.8
+    environment:
+      TRIGGER_TAG: << pipeline.git.tag >>
+    steps:
+      - run:
+          name: clone main repo, publish tag that triggered the pipeline
+          command: |
+            git clone git@github.com:aflorithmic/apiaudio-python.git
+            cd apiaudio-python
+            git checkout $TRIGGER_TAG
+            pip3 install twine wheel
+            python3 setup.py sdist bdist_wheel
+#            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
 
+  update-ssm:
+    environment:
+      TRIGGER_TAG: << pipeline.git.tag >>
+    executor: aws-cli/default
+    steps:
+      - aws-cli/setup:
+          profile-name: versionUpdate
+      - run:
+          name: update SSM parameter with latest SDK version
+          command: |
+            aws ssm get-parameter --name /sdk/latest_versions > ssm.json
+#            NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
+#            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
 
 workflows:
   semgrep-scan:
     jobs:
       - semgrep-scan:
           context: aws
+
+  version-update:
+    jobs:
+      - pip-publish:
+          <<: *only_tags
+
+      - update-ssm:
+          context: aws
+          requires:
+            - pip-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
           command: |
             pip3 install twine wheel
             python3 setup.py sdist bdist_wheel
-#            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
+            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
       - <<: *slack_basic_fail
       - <<: *slack_success_deploy
 
@@ -89,7 +89,7 @@ jobs:
             aws ssm get-parameter --name /sdk/latest_versions > ssm.json
             NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
             echo $NEW_VALUE
-#            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
+            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
       - <<: *slack_basic_fail
       - <<: *slack_success_deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,20 @@ config_blocks:
       tags:
         only: /^v[0-9]+(\.[0-9]+)*$/
 #  ---------------- SLACK CONFIG BLOCK ----------------
-  slack_channel: &slack_channel deployments #slack channel for notifications 
+  slack_channel: &slack_channel deployments #slack channel for notifications
 
-  slack_basic_fail: &slack_basic_fail #on fail 
+  slack_basic_fail: &slack_basic_fail #on fail
     - slack/notify:
         channel: *slack_channel
         event: fail
         template: basic_fail_1
 
-  slack_basic_success: &slack_basic_success #on success 
+  slack_basic_success: &slack_basic_success #on success
     - slack/notify:
         channel: *slack_channel
         event: pass
         template: basic_success_1
- 
+
   slack_success_deploy: &slack_success_deploy #success tag deploy
     - slack/notify:
         channel: *slack_channel
@@ -56,7 +56,7 @@ jobs:
             python -m semgrep_agent \
               --publish-deployment << parameters.semgrep_deployment_id >> \
               --publish-token $SEMGREP_APP_TOKEN
-      #  It runs on every commit and probably will annoy us too much. 
+      #  It runs on every commit and probably will annoy us too much.
       # - <<: *slack_basic_fail
       # - <<: *slack_success_deploy
 
@@ -66,17 +66,15 @@ jobs:
     environment:
       TRIGGER_TAG: << pipeline.git.tag >>
     steps:
+      - checkout
       - run:
           name: clone main repo, publish tag that triggered the pipeline
           command: |
-            mkdir -p ~/.ssh
-            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-            git clone git@github.com:aflorithmic/apiaudio-python.git
-            cd apiaudio-python
-            git checkout $TRIGGER_TAG
+            make
+            pre-commit run --all-files
             pip3 install twine wheel
             python3 setup.py sdist bdist_wheel
-            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
+#            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
       - <<: *slack_basic_fail
       - <<: *slack_success_deploy
 
@@ -91,9 +89,9 @@ jobs:
           name: update SSM parameter with latest SDK version
           command: |
             aws ssm get-parameter --name /sdk/latest_versions > ssm.json
-            cat ssm.json
             NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
-            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
+            echo $NEW_VALUE
+#            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
       - <<: *slack_basic_fail
       - <<: *slack_success_deploy
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
           name: clone main repo, publish tag that triggered the pipeline
           command: |
             make
-            pre-commit run --all-files
+            git commit
             pip3 install twine wheel
             python3 setup.py sdist bdist_wheel
 #            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
@@ -104,6 +104,7 @@ workflows:
   version-update:
     jobs:
       - pip-publish:
+          context: aws
           <<: *only_tags
 
       - update-ssm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ workflows:
           <<: *only_tags
 
       - update-ssm:
+          <<: *only_tags
           context: aws
           requires:
             - pip-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,10 +68,8 @@ jobs:
     steps:
       - checkout
       - run:
-          name: clone main repo, publish tag that triggered the pipeline
+          name: publish tag that triggered the pipeline
           command: |
-            make
-            git commit
             pip3 install twine wheel
             python3 setup.py sdist bdist_wheel
 #            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
       - run:
           name: clone main repo, publish tag that triggered the pipeline
           command: |
+            mkdir -p ~/.ssh
+            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git clone git@github.com:aflorithmic/apiaudio-python.git
             cd apiaudio-python
             git checkout $TRIGGER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
           name: update SSM parameter with latest SDK version
           command: |
             aws ssm get-parameter --name /sdk/latest_versions > ssm.json
+            cat ssm.json
 #            NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
 #            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             git checkout $TRIGGER_TAG
             pip3 install twine wheel
             python3 setup.py sdist bdist_wheel
-#            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
+            python3 -m twine upload --username $PIPY_USERNAME --password $PIPY_PASSWORD dist/*
 
   update-ssm:
     environment:
@@ -65,8 +65,8 @@ jobs:
           command: |
             aws ssm get-parameter --name /sdk/latest_versions > ssm.json
             cat ssm.json
-#            NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
-#            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
+            NEW_VALUE=$(cat ssm.json | python3 -c 'import json,sys,os;obj=json.loads(sys.stdin.read());obj=json.loads(obj["Parameter"]["Value"]);obj["python"]=os.environ["TRIGGER_TAG"];print(obj)')
+            aws ssm put-parameter --name /sdk/latest_versions --type "String" --value $NEW_VALUE --overwrite
 
 workflows:
   semgrep-scan:

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Script methods are:
     - `scriptText` \* [Required] (string) - Text for your script. A script can contain multiple sections and SSML tags. Learn more about scriptText details [here](https://docs.api.audio/docs/script-2)
     - `projectName` (string) - The name of your project. Default value is "default"
     - `moduleName` (string) - The name of your module. Default value is "default"
-    - `scriptName` (string) - The name of your script. Default value is "default" (max 60 characters) 
+    - `scriptName` (string) - The name of your script. Default value is "default" (max 60 characters)
     - `scriptId` (string) - Custom identifier for your script. If scriptId parameter is used, then projectName, moduleName and scriptName are required parameters.
     - `versions` (dictionary) - A dictionary containing different versions of your script text, whereby the key is the version name, and its value is the associated `scriptText`. Version name `v0` is reserved as the default `scriptText`. Default value is "{}"
   - Example:
@@ -788,7 +788,7 @@ Orchestrator methods are:
 		- `scriptText` \* [Required] (str) - Text to synthesize (TTS).
 		- `soundTemplate` (str) - Sound template to use.
 		- `voice` \* [Required] (str) - Name of voice to use.
-  
+
 
 
 - `create_three_sections()` Creates a TTS speech request with 3 sections and adds a sound template to it through mastering.

--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -195,9 +195,9 @@ class APIRequest:
     def _options_request(cls, url=None):
         url = url or f"{apiaudio.api_base}{cls.resource_path}"
         headers = cls._build_header()
-        
+
         r = requests.options(url=url, headers=headers)
-        
+
         cls._expanded_raise_for_status(r)
-        
+
         return r.json()

--- a/apiaudio/api_resources/mastering.py
+++ b/apiaudio/api_resources/mastering.py
@@ -12,7 +12,6 @@ class Mastering(CreatableResource, RetrievableResource, DownloadableResource):
 
     loop_status_code = 202
 
-    
     @classmethod
     def list_presets(cls):
         return cls._get_request(path_param=cls.mastering_preset_list_path)

--- a/apiaudio/api_resources/orchestrator.py
+++ b/apiaudio/api_resources/orchestrator.py
@@ -1,15 +1,15 @@
-from apiaudio.helper_classes import (
-    CreatableResource,
-    HelpResource
-)
+from apiaudio.helper_classes import CreatableResource, HelpResource
+
 
 class CreateMediaWithSound(CreatableResource):
     OBJECT_NAME = "orchestrator"
     resource_path = "/orchestrator/media_with_sound"
 
+
 class CreateAudio(CreatableResource):
     OBJECT_NAME = "orchestrator"
     resource_path = "/orchestrator/create_audio"
+
 
 class CreateThreeSections(CreatableResource):
     OBJECT_NAME = "orchestrator"
@@ -31,10 +31,7 @@ class Orchestrator(CreatableResource, HelpResource):
     @classmethod
     def create_three_sections(cls, **args):
         return cls.download(cls, CreateThreeSections.create(**args))
-        
 
     def download(cls, response):
-        local_filename = cls._download_request(
-            url=response.get("url"), destination="."
-        )
+        local_filename = cls._download_request(url=response.get("url"), destination=".")
         return local_filename

--- a/apiaudio/helper_classes.py
+++ b/apiaudio/helper_classes.py
@@ -17,6 +17,7 @@ class HelpResource(APIRequest):
     def help(cls, **params):
         return cls._options_request()
 
+
 class CreatableResource(APIRequest):
     @classmethod
     def create(cls, **params):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,9 +60,7 @@ def test_script_versions():
     from .assets import test_versions
 
     script = apiaudio.Script.create(
-        scriptId="test_sdk",
-        scriptText="hello...",
-        versions=test_versions
+        scriptId="test_sdk", scriptText="hello...", versions=test_versions
     )
 
     assert script.get("availableVersions") == ["v0"] + [


### PR DESCRIPTION
This pipeline, upon tag push in whichever branch:

### Job 1:
- spins up container on `cimg/python:3.8` image
- checkouts to the **trigger tag**
- **twine upload**

### Job 2:
- spins up container with aws-cli (our aws environment context applied)
- gets SSM parameter /sdk/latest_versions
- changes python version to **trigger tag**
- updates the SSM parameter


Tested as far as I could without actually publishing or updating the SSM parameter, everything seems fine.

@GetOn4 please look into whether this CI is safe for a public repository