### PR TITLE
VC: users resource & new convention proposition

### DIFF
--- a/apiaudio/__init__.py
+++ b/apiaudio/__init__.py
@@ -3,7 +3,7 @@
 
 # Configuration variables
 
-sdk_version = "0.16.6"
+sdk_version = "0.17.0"
 
 api_key = None
 assume_org_id = None

--- a/apiaudio/api_request.py
+++ b/apiaudio/api_request.py
@@ -59,7 +59,7 @@ class APIRequest:
 
         cls._expanded_raise_for_status(r)
 
-        if r.headers["Content-Type"] != "application/json":
+        if "application/json" not in r.headers["Content-Type"]:
             return r.content
         return r.json()
 
@@ -94,19 +94,37 @@ class APIRequest:
         # since aws s3 does not return a body on PUT requests,
         # r.json() does not work here
         return r
-    
+
     @classmethod
     def _put_request(cls, json, url=None, headers=None):
         headers = headers or {}
         url = url or f"{apiaudio.api_base}{cls.resource_path}"
         headers.update(cls._build_header())
-        
+
         r = requests.put(url=url, headers=headers, json=json)
 
         cls._expanded_raise_for_status(r)
 
-        if r.headers["Content-Type"] != "application/json":
+        if "application/json" not in r.headers["Content-Type"]:
             return r.content
+        return r.json()
+
+    @classmethod
+    def _patch_request(cls, json, url=None, headers=None, path_param=None):
+        headers = headers or {}
+        url = url or f"{apiaudio.api_base}{cls.resource_path}"
+        if path_param:
+            url = f"{url}/{path_param}"
+
+        headers.update(cls._build_header())
+
+        r = requests.patch(url=url, headers=headers, json=json)
+
+        cls._expanded_raise_for_status(r)
+
+        if "application/json" not in r.headers["Content-Type"]:
+            return r.content
+
         return r.json()
 
     @classmethod
@@ -192,6 +210,8 @@ class APIRequest:
                 ):  # get all messages in between ""
                     apiaudio._logger.warning(f"{self.OBJECT_NAME.upper()}: {warn}")
 
+            apiaudio._logger.info(f"{self.resource_path} - {res.status_code}")
+            apiaudio._logger.debug(res.text)
             res.raise_for_status()
         except HTTPError as e:
             if res.json():

--- a/apiaudio/api_resources/voiceCloner.py
+++ b/apiaudio/api_resources/voiceCloner.py
@@ -1,0 +1,139 @@
+from typing import Literal, Optional, List, Union
+
+from apiaudio.api_request import APIRequest
+
+from apiaudio.logging import SDKLogger
+
+_logger = SDKLogger(level="INFO")
+
+
+class UsersManager(APIRequest):
+    """
+    CRUD interface for Users resource.
+
+    ...
+
+    Notes:
+    - A user should represent a single person/voice
+    - Verticals are assigned to a user
+    - Uploaded files belong to a user
+    - Trained models belong to a user
+
+    """
+
+    OBJECT_NAME = "VC_Users"
+    resource_path = "/ulvc2/users"
+
+    class User(object):
+        """
+        Representation of a voice cloner user.
+        """
+
+        def __init__(
+            self,
+            id: str,
+            name: Optional[str],
+            gender: Optional[Literal["male", "female", "non-binary", ""]],
+            availableVerticals: Optional[list],
+            selectedVerticals: Optional[list],
+            metadata: Optional[dict],
+            voiceCloningEnabled: Optional[bool],
+            createdAt: str,
+        ):
+            self.id = id
+            self.name = name
+            self.gender = gender
+            self.available_verticals = availableVerticals
+            self.selected_verticals = selectedVerticals
+            self.metadata = metadata
+            self.voice_cloning_enabled = voiceCloningEnabled
+            self.created_at = createdAt
+
+        def get_recording_session(self) -> object:  # session object
+            pass
+
+        def add_recording(self, audio: bytes, utterance: object) -> None:
+            pass
+
+        def trigger_model_training(
+            self, name: str = "", verticals_to_use: list = []
+        ) -> None:
+            pass
+
+    @classmethod
+    def create(
+        cls,
+        id: str = "",
+        name: str = "",
+        gender: Literal["male", "female", "non-binary", ""] = "",
+        available_verticals: list = [],
+        selected_verticals: list = [],
+        metadata: dict = {},
+        voice_cloning_enabled: bool = False,
+    ) -> User:
+        """
+        Create a new user.
+
+        :param id: The user's id. If not provided, it will be generated through uuid4 method.
+        :param name: the name of the user
+        :param gender: the gender of the user - male/female/non-binary
+        :param available_verticals: verticals which can be selected by the user.
+        :param selected_verticals: verticals that are served to the user in recording session
+        :param metadata: additional information about the user
+        :param voice_cloning_enabled: whether the user is allowed to use voice cloning feature
+        """
+        data = cls._post_request(
+            json={
+                "id": id,
+                "name": name,
+                "gender": gender,
+                "availableVerticals": available_verticals,
+                "selectedVerticals": selected_verticals,
+                "metadata": metadata,
+                "voiceCloningEnabled": voice_cloning_enabled,
+            }
+        ).get("data", {})
+
+        return cls.User(**data)
+
+    @classmethod
+    def list(cls) -> List[User]:
+        """
+        List all existing users.
+        """
+        data = cls._get_request().get("data", {})
+
+        return [cls.User(**user) for user in data]
+
+    @classmethod
+    def retrieve(cls, id: str) -> User:
+        """
+        Retrieve a user by id.
+        """
+        data = cls._get_request(path_param=f"{cls.resource_path}/{id}").get("data", {})
+
+        return cls.User(**data)
+
+    @classmethod
+    def update(cls, user: User) -> None:
+        """
+        Update the user. The passed user object gets updated.
+        """
+        data = cls._patch_request(json=vars(user), path_param=user.id).get("data", {})
+
+        user.__init__(**data)
+
+    @classmethod
+    def delete(cls, user: Union[User, str]) -> None:
+        """
+        Delete the user.
+        When passing the user object, all its attributes are set to None.
+        """
+        if isinstance(user, str):
+            user_id = user
+        elif isinstance(user, cls.User):
+            user_id = user.id
+
+        cls._delete_request(path_param=f"{cls.resource_path}/{user_id}").get("data", {})
+        for key in vars(user).keys():
+            setattr(user, key, None)

--- a/apiaudio/api_resources/voiceCloner.py
+++ b/apiaudio/api_resources/voiceCloner.py
@@ -39,6 +39,7 @@ class UsersManager(APIRequest):
             metadata: Optional[dict],
             voiceCloningEnabled: Optional[bool],
             createdAt: str,
+            **kwargs,
         ):
             self.id = id
             self.name = name

--- a/apiaudio/api_resources/voiceCloner.py
+++ b/apiaudio/api_resources/voiceCloner.py
@@ -2,10 +2,6 @@ from typing import Literal, Optional, List, Union
 
 from apiaudio.api_request import APIRequest
 
-from apiaudio.logging import SDKLogger
-
-_logger = SDKLogger(level="INFO")
-
 
 class UsersManager(APIRequest):
     """


### PR DESCRIPTION
## Why not following the convention of previous resources?

@Sjhunt93 and I have been discussing changes to introduce in SDK and so the convention will be changed for v1.0.0 (talking to V2 API at that point).

Briefly:

1. Making inheritance correct. Resources inherit APIRequest, yet instead of overwriting methods, plenty of if conditions are thrashing the original methods. Anti-pattern.

2. There's lots of repeated code in APIRequest because of having separate methods per HTTP method, even though often only one line of code is different. And that's a consequence of decisions mentioned in point 1.

3. Most important. We'll be having resource objects representing the actual API-side entities and their states (as you can see in this PR) instead of returning dictionaries. 

**Benefits are such that we're increasing:** 
- SDK's readability and the accuracy of API's representations (object members annotations in IDEs!), 
- testability (proper client tests, increased probability of catching breaking changes), 
- simplicity of version-specific changes (e.g. SDK-side transformations, API-side version-specific feature flags, extra keys ignored in previous versions etc.)

It just makes more sense. 

### Note
Please try to be critical towards the proposition presented in this PR, because once it's accepted it'll lay foundation to the rest VC resource and likely the incoming refactors for V2.